### PR TITLE
Fix TIMA Issue

### DIFF
--- a/peanut_gb.h
+++ b/peanut_gb.h
@@ -3404,7 +3404,7 @@ void __gb_step_cpu(struct gb_s *gb)
 
 		gb->counter.tima_count += inst_cycles;
 
-		if(gb->counter.tima_count >= TAC_CYCLES[gb->gb_reg.tac_rate])
+		while(gb->counter.tima_count >= TAC_CYCLES[gb->gb_reg.tac_rate])
 		{
 			gb->counter.tima_count -= TAC_CYCLES[gb->gb_reg.tac_rate];
 


### PR DESCRIPTION
The test for cpu instruction timing failed. It turns out if the TAC is set to the fastest speed, TIMA can increment more than once with a single instruction. Changing the "if" to a "while" fixes this. It should not have to run the loop more than 2 times.