### PR TITLE
core: fix enum storage in bitfield

### DIFF
--- a/peanut_gb.h
+++ b/peanut_gb.h
@@ -369,17 +369,16 @@ struct gb_s
 
 	struct
 	{
-		unsigned int	gb_halt : 1;
-		unsigned int	gb_ime : 1;
-		unsigned int	gb_bios_enable : 1;
-		unsigned int	gb_frame : 1; /* New frame drawn. */
-		enum
-		{
-			LCD_HBLANK = 0,
-			LCD_VBLANK = 1,
-			LCD_SEARCH_OAM = 2,
-			LCD_TRANSFER = 3
-		}				lcd_mode : 2;
+		unsigned char	gb_halt : 1;
+		unsigned char	gb_ime : 1;
+		unsigned char	gb_bios_enable : 1;
+		unsigned char	gb_frame : 1; /* New frame drawn. */
+
+#		define LCD_HBLANK	0
+#		define LCD_VBLANK	1
+#		define LCD_SEARCH_OAM	2
+#		define LCD_TRANSFER	3
+		unsigned char	lcd_mode : 2;
 	};
 
 	/* Cartridge information:


### PR DESCRIPTION
Closes issue #46 whereby a compiler may attempt to store a signed
integer within the bitfield.

Signed-off-by: Mahyar Koshkouei <mk@deltabeard.com>