### PR TITLE
fix minifb error, add to gitignore, gb_colour_hash typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 *.o
 *.a
 *.exe
-peanut-sdl
+peanut-sdl*
 peanut-debug
+peanut-minifb
 tags
 build*/
 bin*/

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ returns 0 if the game does not use any save data.
 
 This function runs the CPU until a full frame is rendered to the LCD.
 
-#### gb_color_hash
+#### gb_colour_hash
 
 This function calculates a hash of the game title. This hash is calculated in
 the same way as the Game Boy Color to add colour to Game Boy games.

--- a/examples/mini_fb/peanut_minifb.c
+++ b/examples/mini_fb/peanut_minifb.c
@@ -96,7 +96,7 @@ void gb_error(struct gb_s *gb, const enum gb_error_e gb_err, const uint16_t val)
 	struct priv_t *priv = gb->direct.priv;
 
 	fprintf(stderr, "Error %d occurred: %s at %04X\n. Exiting.\n",
-			gb_err, gb_err_str[gb_err], addr);
+			gb_err, gb_err_str[gb_err], val);
 
 	/* Free memory and then exit. */
 	free(priv->cart_ram);


### PR DESCRIPTION
The * ignores wasm files incase emscripten is used.