### PR TITLE
Use bool for bitfield values

### DIFF
--- a/examples/benchmark/peanut-benchmark.c
+++ b/examples/benchmark/peanut-benchmark.c
@@ -185,7 +185,7 @@ int main(int argc, char **argv)
 
 #if ENABLE_LCD
 		gb_init_lcd(&gb, &lcd_draw_line);
-		// gb.direct.interlace = 1;
+		// gb.direct.interlace = true;
 #endif
 
 		start_time = clock();

--- a/examples/debug/peanut-debug.c
+++ b/examples/debug/peanut-debug.c
@@ -379,8 +379,8 @@ int main(int argc, char **argv)
 		/* Execute CPU cycles until the screen has to be redrawn. */
 		//gb_run_frame(&gb);
 		
-		gb.gb_frame = 0;
-		while(gb.gb_frame == 0)
+		gb.gb_frame = false;
+		while(!gb.gb_frame)
 		{
 			const char *lcd_mode_str[4] = {
 				"HBLANK", "VBLANK", "OAM", "TRANSFER"

--- a/examples/mini_fb/peanut_minifb.c
+++ b/examples/mini_fb/peanut_minifb.c
@@ -159,7 +159,7 @@ int main(int argc, char **argv)
 
 #if ENABLE_LCD
 	gb_init_lcd(&gb, &lcd_draw_line);
-	// gb.direct.interlace = 1;
+	// gb.direct.interlace = true;
 #endif
 
 	if(!mfb_open("Peanut-minifb", LCD_WIDTH, LCD_HEIGHT))

--- a/examples/sdl2/peanut_sdl.c
+++ b/examples/sdl2/peanut_sdl.c
@@ -1118,11 +1118,11 @@ int main(int argc, char **argv)
 #if ENABLE_LCD
 
 				case SDLK_i:
-					gb.direct.interlace = ~gb.direct.interlace;
+					gb.direct.interlace = !gb.direct.interlace;
 					break;
 
 				case SDLK_o:
-					gb.direct.frame_skip = ~gb.direct.frame_skip;
+					gb.direct.frame_skip = !gb.direct.frame_skip;
 					break;
 
 				case SDLK_b:

--- a/test/test_external_rom.c
+++ b/test/test_external_rom.c
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
 	gb_init_serial(&gb, gb_serial_tx, NULL);
 #if ENABLE_LCD
 	gb_init_lcd(&gb, &lcd_draw_line);
-	// gb.direct.interlace = 1;
+	// gb.direct.interlace = true;
 #endif
 
 	do


### PR DESCRIPTION
The `joypad_bits` bitfield has been removed since it relied on specific positions, however the layout is not standardised and may differ between compilers: https://stackoverflow.com/questions/19376426/order-of-fields-when-using-a-bit-field-in-c

The rest of the bitfield have been changed to use `unsigned int` instead of `uint8_t` for compatibility with more compilers.
