### PR TITLE
Deprecate non-portable joypad_bits bitfield

### DIFF
--- a/examples/debug/peanut-debug.c
+++ b/examples/debug/peanut-debug.c
@@ -340,14 +340,14 @@ int main(int argc, char **argv)
 				case SDL_KEYDOWN:
 					switch(event.key.keysym.sym)
 					{
-						case SDLK_RETURN: gb.direct.joypad_bits.start = 0; break;
-						case SDLK_BACKSPACE: gb.direct.joypad_bits.select = 0; break;
-						case SDLK_z: gb.direct.joypad_bits.a = 0; break;
-						case SDLK_x: gb.direct.joypad_bits.b = 0; break;
-						case SDLK_UP: gb.direct.joypad_bits.up = 0; break;
-						case SDLK_DOWN: gb.direct.joypad_bits.down = 0; break;
-						case SDLK_LEFT: gb.direct.joypad_bits.left = 0; break;
-						case SDLK_RIGHT: gb.direct.joypad_bits.right = 0; break;
+						case SDLK_RETURN: gb.direct.joypad &= ~JOYPAD_START; break;
+						case SDLK_BACKSPACE: gb.direct.joypad &= ~JOYPAD_SELECT; break;
+						case SDLK_z: gb.direct.joypad &= ~JOYPAD_A; break;
+						case SDLK_x: gb.direct.joypad &= ~JOYPAD_B; break;
+						case SDLK_UP: gb.direct.joypad &= ~JOYPAD_UP; break;
+						case SDLK_DOWN: gb.direct.joypad &= ~JOYPAD_DOWN; break;
+						case SDLK_LEFT: gb.direct.joypad &= ~JOYPAD_LEFT; break;
+						case SDLK_RIGHT: gb.direct.joypad &= ~JOYPAD_RIGHT; break;
 						case SDLK_SPACE: fast_mode = !fast_mode; break;
 						case SDLK_d: debug_mode = !debug_mode; break;
 						default: break;
@@ -356,14 +356,14 @@ int main(int argc, char **argv)
 				case SDL_KEYUP:
 					switch(event.key.keysym.sym)
 					{
-						case SDLK_RETURN: gb.direct.joypad_bits.start = 1; break;
-						case SDLK_BACKSPACE: gb.direct.joypad_bits.select = 1; break;
-						case SDLK_z: gb.direct.joypad_bits.a = 1; break;
-						case SDLK_x: gb.direct.joypad_bits.b = 1; break;
-						case SDLK_UP: gb.direct.joypad_bits.up = 1; break;
-						case SDLK_DOWN: gb.direct.joypad_bits.down = 1; break;
-						case SDLK_LEFT: gb.direct.joypad_bits.left = 1; break;
-						case SDLK_RIGHT: gb.direct.joypad_bits.right = 1; break;
+						case SDLK_RETURN: gb.direct.joypad |= JOYPAD_START; break;
+						case SDLK_BACKSPACE: gb.direct.joypad |= JOYPAD_SELECT; break;
+						case SDLK_z: gb.direct.joypad |= JOYPAD_A; break;
+						case SDLK_x: gb.direct.joypad |= JOYPAD_B; break;
+						case SDLK_UP: gb.direct.joypad |= JOYPAD_UP; break;
+						case SDLK_DOWN: gb.direct.joypad |= JOYPAD_DOWN; break;
+						case SDLK_LEFT: gb.direct.joypad |= JOYPAD_LEFT; break;
+						case SDLK_RIGHT: gb.direct.joypad |= JOYPAD_RIGHT; break;
 						default: break;
 					}
 					break;

--- a/examples/sdl2/peanut_sdl.c
+++ b/examples/sdl2/peanut_sdl.c
@@ -1011,39 +1011,76 @@ int main(int argc, char **argv)
 				goto quit;
 
 			case SDL_CONTROLLERBUTTONDOWN:
+				switch(event.cbutton.button)
+				{
+				case SDL_CONTROLLER_BUTTON_A:
+					gb.direct.joypad &= ~JOYPAD_A;
+					break;
+
+				case SDL_CONTROLLER_BUTTON_B:
+					gb.direct.joypad &= ~JOYPAD_B;
+					break;
+
+				case SDL_CONTROLLER_BUTTON_BACK:
+					gb.direct.joypad &= ~JOYPAD_SELECT;
+					break;
+
+				case SDL_CONTROLLER_BUTTON_START:
+					gb.direct.joypad &= ~JOYPAD_START;
+					break;
+
+				case SDL_CONTROLLER_BUTTON_DPAD_UP:
+					gb.direct.joypad &= ~JOYPAD_UP;
+					break;
+
+				case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+					gb.direct.joypad &= ~JOYPAD_RIGHT;
+					break;
+
+				case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+					gb.direct.joypad &= ~JOYPAD_DOWN;
+					break;
+
+				case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+					gb.direct.joypad &= ~JOYPAD_LEFT;
+					break;
+				}
+
+				break;
+
 			case SDL_CONTROLLERBUTTONUP:
 				switch(event.cbutton.button)
 				{
 				case SDL_CONTROLLER_BUTTON_A:
-					gb.direct.joypad_bits.a = !event.cbutton.state;
+					gb.direct.joypad |= JOYPAD_A;
 					break;
 
 				case SDL_CONTROLLER_BUTTON_B:
-					gb.direct.joypad_bits.b = !event.cbutton.state;
+					gb.direct.joypad |= JOYPAD_B;
 					break;
 
 				case SDL_CONTROLLER_BUTTON_BACK:
-					gb.direct.joypad_bits.select = !event.cbutton.state;
+					gb.direct.joypad |= JOYPAD_SELECT;
 					break;
 
 				case SDL_CONTROLLER_BUTTON_START:
-					gb.direct.joypad_bits.start = !event.cbutton.state;
+					gb.direct.joypad |= JOYPAD_START;
 					break;
 
 				case SDL_CONTROLLER_BUTTON_DPAD_UP:
-					gb.direct.joypad_bits.up = !event.cbutton.state;
+					gb.direct.joypad |= JOYPAD_UP;
 					break;
 
 				case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
-					gb.direct.joypad_bits.right = !event.cbutton.state;
+					gb.direct.joypad |= JOYPAD_RIGHT;
 					break;
 
 				case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
-					gb.direct.joypad_bits.down = !event.cbutton.state;
+					gb.direct.joypad |= JOYPAD_DOWN;
 					break;
 
 				case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
-					gb.direct.joypad_bits.left = !event.cbutton.state;
+					gb.direct.joypad |= JOYPAD_LEFT;
 					break;
 				}
 
@@ -1053,43 +1090,43 @@ int main(int argc, char **argv)
 				switch(event.key.keysym.sym)
 				{
 				case SDLK_RETURN:
-					gb.direct.joypad_bits.start = 0;
+					gb.direct.joypad &= ~JOYPAD_START;
 					break;
 
 				case SDLK_BACKSPACE:
-					gb.direct.joypad_bits.select = 0;
+					gb.direct.joypad &= ~JOYPAD_SELECT;
 					break;
 
 				case SDLK_z:
-					gb.direct.joypad_bits.a = 0;
+					gb.direct.joypad &= ~JOYPAD_A;
 					break;
 
 				case SDLK_x:
-					gb.direct.joypad_bits.b = 0;
+					gb.direct.joypad &= ~JOYPAD_B;
 					break;
 
 				case SDLK_a:
-					gb.direct.joypad_bits.a = ~gb.direct.joypad_bits.a;
+					gb.direct.joypad ^= JOYPAD_A;
 					break;
 
 				case SDLK_s:
-					gb.direct.joypad_bits.b = ~gb.direct.joypad_bits.b;
+					gb.direct.joypad ^= JOYPAD_B;
 					break;
 
 				case SDLK_UP:
-					gb.direct.joypad_bits.up = 0;
+					gb.direct.joypad &= ~JOYPAD_UP;
 					break;
 
 				case SDLK_RIGHT:
-					gb.direct.joypad_bits.right = 0;
+					gb.direct.joypad &= ~JOYPAD_RIGHT;
 					break;
 
 				case SDLK_DOWN:
-					gb.direct.joypad_bits.down = 0;
+					gb.direct.joypad &= ~JOYPAD_DOWN;
 					break;
 
 				case SDLK_LEFT:
-					gb.direct.joypad_bits.left = 0;
+					gb.direct.joypad &= ~JOYPAD_LEFT;
 					break;
 
 				case SDLK_SPACE:
@@ -1160,43 +1197,43 @@ int main(int argc, char **argv)
 				switch(event.key.keysym.sym)
 				{
 				case SDLK_RETURN:
-					gb.direct.joypad_bits.start = 1;
+					gb.direct.joypad |= JOYPAD_START;
 					break;
 
 				case SDLK_BACKSPACE:
-					gb.direct.joypad_bits.select = 1;
+					gb.direct.joypad |= JOYPAD_SELECT;
 					break;
 
 				case SDLK_z:
-					gb.direct.joypad_bits.a = 1;
+					gb.direct.joypad |= JOYPAD_A;
 					break;
 
 				case SDLK_x:
-					gb.direct.joypad_bits.b = 1;
+					gb.direct.joypad |= JOYPAD_B;
 					break;
 
 				case SDLK_a:
-					gb.direct.joypad_bits.a = 1;
+					gb.direct.joypad |= JOYPAD_A;
 					break;
 
 				case SDLK_s:
-					gb.direct.joypad_bits.b = 1;
+					gb.direct.joypad |= JOYPAD_B;
 					break;
 
 				case SDLK_UP:
-					gb.direct.joypad_bits.up = 1;
+					gb.direct.joypad |= JOYPAD_UP;
 					break;
 
 				case SDLK_RIGHT:
-					gb.direct.joypad_bits.right = 1;
+					gb.direct.joypad |= JOYPAD_RIGHT;
 					break;
 
 				case SDLK_DOWN:
-					gb.direct.joypad_bits.down = 1;
+					gb.direct.joypad |= JOYPAD_DOWN;
 					break;
 
 				case SDLK_LEFT:
-					gb.direct.joypad_bits.left = 1;
+					gb.direct.joypad |= JOYPAD_LEFT;
 					break;
 
 				case SDLK_SPACE:

--- a/peanut_gb.h
+++ b/peanut_gb.h
@@ -683,17 +683,18 @@ struct gb_s
 		{
 			struct
 			{
-				/* Using this bitfield is deprecated due to portability concerns.
-				 * It is recommended to use the JOYPAD_* defines instead.
+				/* Using this bitfield is deprecated due to
+				 * portability concerns. It is recommended to
+				 * use the JOYPAD_* defines instead.
 				 */
-				uint8_t a	: 1;
-				uint8_t b	: 1;
-				uint8_t select	: 1;
-				uint8_t start	: 1;
-				uint8_t right	: 1;
-				uint8_t left	: 1;
-				uint8_t up	: 1;
-				uint8_t down	: 1;
+				bool a		: 1;
+				bool b		: 1;
+				bool select	: 1;
+				bool start	: 1;
+				bool right	: 1;
+				bool left	: 1;
+				bool up		: 1;
+				bool down	: 1;
 			} joypad_bits;
 			uint8_t joypad;
 		};

--- a/peanut_gb.h
+++ b/peanut_gb.h
@@ -219,6 +219,16 @@
 #define OBJ_FLIP_X          0x20
 #define OBJ_PALETTE         0x10
 
+/* Joypad buttons */
+#define JOYPAD_A            0x01
+#define JOYPAD_B            0x02
+#define JOYPAD_SELECT       0x04
+#define JOYPAD_START        0x08
+#define JOYPAD_RIGHT        0x10
+#define JOYPAD_LEFT         0x20
+#define JOYPAD_UP           0x40
+#define JOYPAD_DOWN         0x80
+
 #define ROM_HEADER_CHECKSUM_LOC	0x014D
 
 /* Local macros. */
@@ -672,6 +682,9 @@ struct gb_s
 		{
 			struct
 			{
+				/* Using this bitfield is deprecated due to portability concerns.
+				 * It is recommended to use the JOYPAD_* defines instead.
+				 */
 				uint8_t a	: 1;
 				uint8_t b	: 1;
 				uint8_t select	: 1;


### PR DESCRIPTION
This has been split out from PR #103 and modified to simply deprecate the bitfield rather than outright removing it.

> The `joypad_bits` bitfield has been removed since it relied on specific positions, however the layout is not standardised and may differ between compilers: https://stackoverflow.com/questions/19376426/order-of-fields-when-using-a-bit-field-in-c
