### PR TITLE
Avoid use of integer division

### DIFF
--- a/peanut_gb.h
+++ b/peanut_gb.h
@@ -3385,7 +3385,10 @@ void __gb_step_cpu(struct gb_s *gb)
 			gb->counter.lcd_count -= LCD_LINE_CYCLES;
 
 			/* Next line */
-			gb->hram_io[IO_LY] = (gb->hram_io[IO_LY] + 1) % LCD_VERT_LINES;
+			if (gb->hram_io[IO_LY] + 1 < LCD_VERT_LINES)
+				gb->hram_io[IO_LY] = gb->hram_io[IO_LY] + 1;
+			else
+				gb->hram_io[IO_LY] = 0;
 
 			/* LYC Update */
 			if(gb->hram_io[IO_LY] == gb->hram_io[IO_LYC])


### PR DESCRIPTION
This should help a bit on architectures without dedicated instructions for integer division.