### PR TITLE
Debugger: Fix freed argv pointer

### DIFF
--- a/examples/debug/peanut-debug-simple.c
+++ b/examples/debug/peanut-debug-simple.c
@@ -305,7 +305,8 @@ quit:
 
 	free(priv.rom);
 	free(priv.cart_ram);
-	free(save_file_name);
+	if(argc == 2)
+		free(save_file_name);
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary
- skip freeing `argv[2]` when no save file buffer was allocated

## Testing
- `make -C test`
- `make -C examples/debug peanut-debug-simple`

------
https://chatgpt.com/codex/tasks/task_e_684023f9b50c8333b8839520ec97b705