### PR TITLE
Fix out-of-bounds write in per-line sprite buffer

### DIFF
--- a/peanut_gb.h
+++ b/peanut_gb.h
@@ -1644,7 +1644,7 @@ void __gb_draw_line(struct gb_s *gb)
 #if PEANUT_GB_HIGH_LCD_ACCURACY
 		uint8_t number_of_sprites = 0;
 
-		struct sprite_data sprites_to_render[MAX_SPRITES_LINE];
+		struct sprite_data sprites_to_render[MAX_SPRITES_LINE + 1];
 
 		/* Record number of sprites on the line being rendered, limited
 		 * to the maximum number sprites that the Game Boy is able to


### PR DESCRIPTION
* Increased the size of the per-line sprite array by **1**, providing a safe slot during sprite insertion and sorting

The per-line sprite buffer is used to **sort sprites for each scanline**, preserving the Game Boy’s rendering order and priority rules.

In certain **DMG-only titles**, the insertion logic can temporarily exceed `MAX_SPRITES_LINE` while maintaining sort order. Because the array was allocated with exactly `MAX_SPRITES_LINE` elements, this results in a **one-element out-of-bounds write**, leading to stack corruption or crashes.

This was observed in a **clean CMake build of the SDL2 demo on Windows 11 using the existing build scripts**, but does **not occur in the precompiled 1.3.0 binary**. Reproducible cases include:

- **Donkey Kong Land** (at the completion of any jump)
- **Pokémon Blue** (during the title screen transition, after logo)

The fix increases the array size by one element to safely accommodate the temporary insertion step during sprite sorting.
